### PR TITLE
Fix: Sort coordinates before groupby in remove_duplicates_in_line

### DIFF
--- a/wayfarer/linearref.py
+++ b/wayfarer/linearref.py
@@ -394,7 +394,7 @@ def remove_duplicates_in_line(line: LineString):
     if line.geom_type != "LineString":
         raise NotImplementedError(f"Geometry type {line.geom_type} is not valid")
 
-    clean_coords = [k for k, g in itertools.groupby(line.coords)]
+    clean_coords = [k for k, g in itertools.groupby(sorted(line.coords))]
     return LineString(clean_coords)
 
 


### PR DESCRIPTION
## Description  
Fixes the `remove_duplicates_in_line` function to remove all duplicate coordinates, not just consecutive ones, by ensuring the list is sorted before calling `groupby`.

## Problem  
The current implementation of `remove_duplicates_in_line` uses `itertools.groupby` without first sorting the coordinates. As a result, only consecutive identical coordinates are considered duplicates.

## Solution  
Added a sorting step before applying the `groupby` function to ensure that all duplicate coordinates are identified and removed, regardless of their position in the `LineString`.

## Example:

```python
import itertools
from shapely.geometry import LineString

# original version
def remove_duplicates_in_line_original(line):
    if line.geom_type != "LineString":
        raise NotImplementedError(f"Geometry type {line.geom_type} is not valid")
    clean_coords = [k for k, g in itertools.groupby(line.coords)]
    return LineString(clean_coords)

# fixed version
def remove_duplicates_in_line_fixed(line):
    if line.geom_type != "LineString":
        raise NotImplementedError(f"Geometry type {line.geom_type} is not valid")
    clean_coords = [k for k, g in itertools.groupby(sorted(line.coords))]
    return LineString(clean_coords)

# LineString with non-consecutive duplicates
ls = LineString([(0, 0), (1, 1), (2, 2), (1, 1), (3, 3)])

# applying the original function
ls_clean_original = remove_duplicates_in_line_original(ls)
print("Original function result:", list(ls_clean_original.coords))
# output: [(0, 0), (1, 1), (2, 2), (1, 1), (3, 3)]
# The duplicate (1,1) is not removed because it is non-consecutive.

# applying the fixed function
ls_clean_fixed = remove_duplicates_in_line_fixed(ls)
print("Fixed function result:", list(ls_clean_fixed.coords))
# output: [(0, 0), (1, 1), (2, 2), (3, 3)]
# now, all duplicates are properly removed.
