### PR TITLE
Allow MultiDiGraph to be used with `solve_shortest_path_from_edges`

### DIFF
--- a/tests/networks.py
+++ b/tests/networks.py
@@ -2,6 +2,7 @@
 This file contains a collection of various network forms
 """
 
+from networkx import MultiDiGraph, MultiGraph
 from wayfarer import (
     EDGE_ID_FIELD,
     LENGTH_FIELD,
@@ -11,7 +12,7 @@ from wayfarer import (
 )
 
 
-def tuples_to_net(tuples):
+def tuples_to_net(tuples, graph_type=MultiGraph):
     """
     Takes in a list of tuples in the form (1, 1, 2, 10) and
     converts to {'EDGE_ID': 1, 'NODEID_FROM': 1, 'NODEID_TO': 2, 'LEN_': 10}
@@ -21,7 +22,7 @@ def tuples_to_net(tuples):
     fields = [EDGE_ID_FIELD, NODEID_FROM_FIELD, NODEID_TO_FIELD, LENGTH_FIELD]
     recs = [dict(zip(fields, t)) for t in tuples]
     # print(recs)
-    return loader.load_network_from_records(recs)
+    return loader.load_network_from_records(recs, graph_type=graph_type)
 
 
 def simple_network():
@@ -31,6 +32,14 @@ def simple_network():
 
     data = [(1, 1, 2, 10), (2, 2, 3, 10), (3, 3, 4, 10), (4, 4, 5, 10)]
     return tuples_to_net(data)
+
+
+def simple_network_directed():
+    """
+    Same as simple_network, but as a MultiDiGraph
+    """
+    data = [(1, 1, 2, 10), (2, 2, 3, 10), (3, 3, 4, 10), (4, 4, 5, 10)]
+    return tuples_to_net(data, graph_type=MultiDiGraph)
 
 
 def reverse_network():

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -110,6 +110,46 @@ def test_solve_shortest_path_split_network():
     ]
 
 
+def test_solve_shortest_path_from_edges_directed():
+    """
+    solve_shortest_path_from_edges should return edges in the correct
+    directed order
+    """
+    net = networks.simple_network_directed()
+    assert net.is_directed()
+
+    edges = routing.solve_shortest_path_from_edges(net, [1, 2, 3, 4])
+    edge_ids = [edge.key for edge in edges]
+    assert edge_ids == [1, 2, 3, 4]
+
+
+def test_solve_shortest_path_from_edges_directed_random_order():
+    """
+    Input edge_id_list order shouldn't affect the resulting directed path
+    """
+
+    net = networks.simple_network_directed()
+    edges = routing.solve_shortest_path_from_edges(net, [4, 3, 1, 2])
+    edge_ids = [edge.key for edge in edges]
+    assert edge_ids == [1, 2, 3, 4]
+
+
+def test_solve_shortest_path_from_edges_with_undirected_net_param():
+    """
+    Pass a pre-built undirected_net
+    """
+
+    net = networks.simple_network_directed()
+    undirected_net = net.to_undirected()
+
+    edges_default = routing.solve_shortest_path_from_edges(net, [1, 2, 3, 4])
+    edges_with_param = routing.solve_shortest_path_from_edges(
+        net, [1, 2, 3, 4], undirected_net=undirected_net
+    )
+
+    assert [e.key for e in edges_default] == [e.key for e in edges_with_param]
+
+
 def test_doctest():
     import doctest
 

--- a/wayfarer/routing.py
+++ b/wayfarer/routing.py
@@ -61,14 +61,40 @@ def solve_shortest_path_from_nodes(
 
 
 def solve_shortest_path_from_edges(
-    net: networkx.MultiGraph | networkx.MultiDiGraph, edge_id_list: list[int | str]
+    net: networkx.MultiGraph | networkx.MultiDiGraph,
+    edge_id_list: list[int | str],
+    undirected_net: networkx.MultiGraph | None = None,
 ):
     """
     Return a path routing from edge to edge, rather than
     from node to node
+
+    If ``net`` is directed routing is run on an undirected
+    copy internally, and the final result is re-solved against the
+    original directed graph to get the correct direction
+
+    Building the undirected copy can take a long time, so if using
+    this function in a loop, then build the undirected network outside
+    the loop and use the ``undirected_net`` parameter
     """
 
     log.debug(f"Edge ids used for path solve: {edge_id_list}")
+
+    is_directed = net.is_directed()
+
+    if is_directed:
+        original_net = net
+        if undirected_net is not None:
+
+            if len(undirected_net) != len(net):
+                raise ValueError("undirected_net does not match net")
+
+            net = undirected_net
+        else:
+            log.info(
+                "Building an undirected network. Consider using the undirected_net parameter to avoid this"
+            )
+            net = net.to_undirected()
 
     # remove any duplicates
     edge_id_list = functions.get_unique_ordered_list(edge_id_list)
@@ -173,7 +199,17 @@ def solve_shortest_path_from_edges(
     # start_edge = functions.get_edge_by_key(net, start_key)
     # start_node = start_edge.start_node
 
-    return find_ordered_path(solved_edges, start_node=None)
+    ordered_path = find_ordered_path(solved_edges, start_node=None)
+
+    if is_directed:
+        # solve on the original directed graph so edge directions are correct
+        start_node, end_node = get_path_ends(ordered_path)
+        try:
+            ordered_path = solve_shortest_path(original_net, start_node, end_node)
+        except NetworkXNoPath:
+            ordered_path = solve_shortest_path(original_net, end_node, start_node)
+
+    return ordered_path
 
 
 def solve_matching_path(


### PR DESCRIPTION
`solve_shortest_path_from_edges` now handles directed graphs correctly. For MultiDiGraph inputs, it performs routing on an undirected copy, then re-solves the path against the original directed graph (trying both directions) before returning the result. 

An optional `undirected_net` parameter was also added so if used in a loop you can avoid repeated and expensive `net.to_undirected()` calls.